### PR TITLE
Fixed the problem with incorrect path to the resources for Unix-like OS

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -5,8 +5,6 @@ Bundle-SymbolicName: studentlog;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
- org.eclipse.equinox.ds,
- org.eclipse.equinox.util,
  org.eclipse.equinox.event,
  org.eclipse.core.commands,
  org.eclipse.ui.workbench,

--- a/src/studentlog/services/ProjectPathFinder.java
+++ b/src/studentlog/services/ProjectPathFinder.java
@@ -19,7 +19,7 @@ public class ProjectPathFinder {
 //			filePath = Platform.resolve(pluginInternalURL).getFile(); pre 3.2 eclipse version
 			
 			projectAbsolutePath = FileLocator.resolve(projectURL).getFile(); //after 3.2 eclipse version
-			if (projectAbsolutePath.charAt(0) == '\\' || projectAbsolutePath.charAt(0) == '/') { 
+			if (projectAbsolutePath.charAt(0) == '\\') { 
 				projectAbsolutePath = projectAbsolutePath.substring(1); 
 			} 
 			return projectAbsolutePath;


### PR DESCRIPTION
**Description:** In the code there is a place where leading slashes are cut to submit a correct absolute path. But it is correct for Windows OS only. For Unix-like OS the first slash is critically important.
Also, redundant dependencies were removed from the Manifest.